### PR TITLE
Fix: ndt7 parsing error

### DIFF
--- a/config/measurements/modules/ndt7.py
+++ b/config/measurements/modules/ndt7.py
@@ -124,14 +124,15 @@ def parse_output(output):
                         ul_bytes = num_bytes
 
             if (not key) and (not value):
+                # Handle the actual NDT7 output format
                 result = {
-                    'download': response["Download"]["Value"],
-                    'upload': response["Upload"]["Value"],
-                    'downloadretrans': response["DownloadRetrans"]["Value"],
-                    'minrtt': response["MinRTT"]["Value"],
+                    'download': response["Download"]["Throughput"]["Value"],
+                    'upload': response["Upload"]["Throughput"]["Value"],
+                    'downloadretrans': response["Download"]["Retransmission"]["Value"],
+                    'minrtt': response["Download"]["Latency"]["Value"],
                     'server': response["ServerFQDN"],
                     'server_ip': response["ServerIP"],
-                    'downloaduuid': response["DownloadUUID"],
+                    'downloaduuid': response["Download"]["UUID"],
                     'meta': {}
                 }
     


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of NDT7 output to accurately extract throughput, retransmission, and latency metrics.
  * Corrected handling of unique identifiers for download measurements.

* **Documentation**
  * Added a comment clarifying the handling of the actual NDT7 output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->